### PR TITLE
Fixed stacking bottom nav bar after logging in

### DIFF
--- a/lib/View/LayoutScreens/UserProfilepageLayout/UserInfoNav.dart
+++ b/lib/View/LayoutScreens/UserProfilepageLayout/UserInfoNav.dart
@@ -10,7 +10,6 @@ import '../../subscreen/myProfile/profiles.dart';
 import '../../subscreen/myProfile/virtual_profile_page.dart';
 import '../../widges/profileMenu.dart';
 
-
 class UserInfoNav extends StatefulWidget {
   const UserInfoNav({super.key});
 
@@ -22,7 +21,7 @@ class _UserInfoNavState extends State<UserInfoNav> {
   @override
   Widget build(BuildContext context) {
     return SizedBox(
-      height: MediaQuery.of(context).size.height<732?0.36.sh:0.42.sh,
+      height: MediaQuery.of(context).size.height < 732 ? 0.36.sh : 0.42.sh,
       child: SingleChildScrollView(
         child: Column(
           children: <Widget>[
@@ -34,10 +33,9 @@ class _UserInfoNavState extends State<UserInfoNav> {
                   context,
                   MaterialPageRoute(
                     builder: (context) => const VirtualProfileScreen(),
-                  ),);
-
+                  ),
+                );
               },
-
               endIcon: true,
               textColor: ColorHandler.normalFont,
             ),
@@ -66,8 +64,10 @@ class _UserInfoNavState extends State<UserInfoNav> {
               icon: IconHandler.artical,
               title: "Profiles",
               onPressed: () {
-                Navigator.push(context, MaterialPageRoute(builder: (context)=>const UserProfilesScreen()));
-
+                Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (context) => const UserProfilesScreen()));
               },
               endIcon: true,
               textColor: ColorHandler.normalFont,
@@ -77,7 +77,14 @@ class _UserInfoNavState extends State<UserInfoNav> {
               title: "Logout",
               onPressed: () async {
                 await FirebaseAuth.instance.signOut();
-                Navigator.push(context, MaterialPageRoute(builder: (context)=>const LoginScreen()));
+                Navigator.of(context, rootNavigator: true).pushAndRemoveUntil(
+                  MaterialPageRoute(
+                    builder: (BuildContext context) {
+                      return LoginScreen();
+                    },
+                  ),
+                  (_) => false,
+                );
                 Phoenix.rebirth(context);
               },
               endIcon: false,


### PR DESCRIPTION
## Context
This PR provides a solution to the issue #9 

## Description 
Earlier when the user used to log out, the navigation bar would still be there, and after logging in the navigation bar would stack, which is not intended.

## Changes
The change is done in lib\View\LayoutScreens\UserProfilepageLayout\UserInfoNav.dart file, where the proper navigation to the login page is handled properly.